### PR TITLE
https URL for aaronpk/slack-ruby-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org/'
 
 gem 'rake'
 
-gem 'slack-ruby-client', git: 'git@github.com:aaronpk/slack-ruby-client.git'
+gem 'slack-ruby-client', git: 'https://github.com/aaronpk/slack-ruby-client.git'
 gem 'cinch'
 
 gem 'celluloid-io', require: ['celluloid/current', 'celluloid/io']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:aaronpk/slack-ruby-client.git
+  remote: https://github.com/aaronpk/slack-ruby-client.git
   revision: 613dd1f5494e63fabd42f41342a0ce4b83307c1e
   specs:
     slack-ruby-client (0.7.5)


### PR DESCRIPTION
Accessing Github over HTTPS is more practical for deployment. Not sure about your dev workflow?